### PR TITLE
pass in appname - useful for generating a test network

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 Configuration module used by [`scuttlebot`](https://github.com/ssbc/scuttlebot).
 
+## example
+
+``` js
+var config = require('ssb-config')()
+
+//if you want to set up a test network, that
+//doesn't collide with main ssb pass the name of that network in.
+
+var test_config = require('ssb-config')('testnet')
+
+```
+
 ## Configuration
 
 * `host` *(string)* The domain or ip address for `sbot`. Defaults to your public ip address.

--- a/index.js
+++ b/index.js
@@ -1,24 +1,30 @@
 var path = require('path')
 var home = require('osenv').home
 var nonPrivate = require('non-private-ip')
+var merge = require('deep-extend')
 
-module.exports = require('rc')('ssb', {
-  //just use an ipv4 address by default.
-  //there have been some reports of seemingly non-private
-  //ipv6 addresses being returned and not working.
-  //https://github.com/ssbc/scuttlebot/pull/102
-  host: nonPrivate.v4 || '',
-  port: 8008,
-  timeout: 30000,
-  pub: true,
-  local: true,
-  phoenix: true,
-  friends: {
-    dunbar: 150,
-    hops: 3
-  },
-  gossip: {
-    connections: 2
-  },
-  path: path.join(home(), '.ssb')
-})
+var RC = require('rc')
+
+module.exports = function (name, override) {
+  name = name || 'ssb'
+  return RC(name || 'ssb', merge({
+    //just use an ipv4 address by default.
+    //there have been some reports of seemingly non-private
+    //ipv6 addresses being returned and not working.
+    //https://github.com/ssbc/scuttlebot/pull/102
+    host: nonPrivate.v4 || '',
+    port: 8008,
+    timeout: 30000,
+    pub: true,
+    local: true,
+    phoenix: true,
+    friends: {
+      dunbar: 150,
+      hops: 3
+    },
+    gossip: {
+      connections: 2
+    },
+    path: path.join(home(), '.' + name)
+  }, override || {}))
+}

--- a/index.js
+++ b/index.js
@@ -1,30 +1,3 @@
-var path = require('path')
-var home = require('osenv').home
-var nonPrivate = require('non-private-ip')
-var merge = require('deep-extend')
 
-var RC = require('rc')
 
-module.exports = function (name, override) {
-  name = name || 'ssb'
-  return RC(name || 'ssb', merge({
-    //just use an ipv4 address by default.
-    //there have been some reports of seemingly non-private
-    //ipv6 addresses being returned and not working.
-    //https://github.com/ssbc/scuttlebot/pull/102
-    host: nonPrivate.v4 || '',
-    port: 8008,
-    timeout: 30000,
-    pub: true,
-    local: true,
-    phoenix: true,
-    friends: {
-      dunbar: 150,
-      hops: 3
-    },
-    gossip: {
-      connections: 2
-    },
-    path: path.join(home(), '.' + name)
-  }, override || {}))
-}
+module.exports = require('./inject')()

--- a/inject.js
+++ b/inject.js
@@ -1,0 +1,30 @@
+var path = require('path')
+var home = require('osenv').home
+var nonPrivate = require('non-private-ip')
+var merge = require('deep-extend')
+
+var RC = require('rc')
+
+module.exports = function (name, override) {
+  name = name || 'ssb'
+  return RC(name || 'ssb', merge({
+    //just use an ipv4 address by default.
+    //there have been some reports of seemingly non-private
+    //ipv6 addresses being returned and not working.
+    //https://github.com/ssbc/scuttlebot/pull/102
+    host: nonPrivate.v4 || '',
+    port: 8008,
+    timeout: 30000,
+    pub: true,
+    local: true,
+    phoenix: true,
+    friends: {
+      dunbar: 150,
+      hops: 3
+    },
+    gossip: {
+      connections: 2
+    },
+    path: path.join(home(), '.' + name)
+  }, override || {}))
+}

--- a/package.json
+++ b/package.json
@@ -8,9 +8,10 @@
     "url": "git://github.com/dominictarr/ssb-config.git"
   },
   "dependencies": {
+    "deep-extend": "^0.4.0",
+    "non-private-ip": "^1.2.1",
     "osenv": "~0.1.0",
-    "rc": "~0.6.0",
-    "non-private-ip": "~1.2.0"
+    "rc": "~0.6.0"
   },
   "devDependencies": {},
   "author": "Dominic Tarr <dominic.tarr@gmail.com> (http://dominictarr.com)",

--- a/test.js
+++ b/test.js
@@ -1,0 +1,3 @@
+
+
+console.log(require('./')('testnet', {port: 9999, friends: {dunbar: 1500}}))


### PR DESCRIPTION
This change makes it easy to reuse ssb-config for a test network.
basically, you pass in your own appname, so that it doesn't reuse main config,
and generates a new database, etc

minor change, backwards compatible.