### PR TITLE
Fix issue where `override` is undefined

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -12,7 +12,7 @@ var MIN = 60*SEC
 module.exports = function (name, override) {
   name = name || 'ssb'
   var HOME = home() || 'browser' //most probably browser
-  var port = override.port || 8008
+  var port = override && override.port || 8008
   return RC(name || 'ssb', merge({
     //just use an ipv4 address by default.
     //there have been some reports of seemingly non-private


### PR DESCRIPTION
It looks like #19 introduced a regression that I found with bench-ssb. This PR resolves the issue.

```
/home/christianbundy/src/bench-ssb/node_modules/ssb-config/inject.js:15
  var port = override.port || 8008
                      ^

TypeError: Cannot read property 'port' of undefined
    at module.exports (/home/christianbundy/src/bench-ssb/node_modules/ssb-config/inject.js:15:23)
    at module.exports (/home/christianbundy/src/bench-ssb/node_modules/ssb-client/index.js:45:14)
    at /home/christianbundy/src/bench-ssb/09-sbot-replicate.js:30:24
    at /home/christianbundy/src/bench-ssb/node_modules/secure-scuttlebutt/index.js:159:7
    at get (/home/christianbundy/src/bench-ssb/node_modules/flumeview-reduce/inject.js:115:11)
    at /home/christianbundy/src/bench-ssb/node_modules/flumedb/wrap.js:45:11
    at /home/christianbundy/src/bench-ssb/node_modules/flumedb/wrap.js:27:54
    at trigger (/home/christianbundy/src/bench-ssb/node_modules/obv/index.js:17:22)
    at Function.many.set (/home/christianbundy/src/bench-ssb/node_modules/obv/index.js:33:47)
    at /home/christianbundy/src/bench-ssb/node_modules/flumelog-offset/inject.js:60:11
```

This could also be something like:

```js
var port
if (typeof override === 'object' && override.port) {
  port = override.port
} else {
  port = 8008
}
```

But it's quite a bit more verbose for (seemingly?) no benefit. Let me know if that's the preference. Thanks!