### PR TITLE
Add a 2nd default incoming for websocket connections

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -62,7 +62,8 @@ module.exports = function (name, override) {
 
   if (!result.connections.incoming) {
     result.connections.incoming = {
-      net: [{ host: result.host, port: result.port, scope: "public", "transform": "shs" }]
+      net: [{ host: result.host, port: result.port, scope: "public", "transform": "shs" }],
+      ws: [{ host: result.host, port: result.ws.port, scope: "device", "transform": "shs" }]
     }
   }
   return result

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ssb-config",
   "description": "load ssb config",
-  "version": "2.3.5",
+  "version": "2.3.6",
   "homepage": "https://github.com/ssbc/ssb-config",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This fixes a regression introduced with the new connection code.
sbot used to listen for incoming websocket connections un 11.x.
This patch restores that behaviour.