### PR TITLE
Create additional incomings for localhost

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -18,7 +18,7 @@ module.exports = function (name, override) {
     //ipv6 addresses being returned and not working.
     //https://github.com/ssbc/scuttlebot/pull/102
     party: true,
-    host: nonPrivate.v4 || '',
+    host: nonPrivate.v4 || nonPrivate.private.v4 || '',
     port: 8008,
     timeout: 0,
     pub: true,
@@ -61,9 +61,23 @@ module.exports = function (name, override) {
   }, override || {}))
 
   if (!result.connections.incoming) {
+      var net1 = { port: result.port, scope: "public", "transform": "shs" }
+      if (result.host) net1.host = result.host
+      var net2 = { port: result.port, scope: "device", "transform": "shs" }
+      // host intentionally left blank in net2
+
+      var ws1 = { port: result.ws.port, scope: "public", "transform": "shs" }
+      if (result.host) ws1.host = result.host
+      var ws2 = { port: result.ws.port, scope: "device", "transform": "shs" }
+      // host intentionally left blank in ws2
+
     result.connections.incoming = {
-      net: [{ host: result.host, port: result.port, scope: "public", "transform": "shs" }],
-      ws: [{ host: result.host, port: result.ws.port, scope: "device", "transform": "shs" }]
+      net: [net1],
+      ws: [ws1]
+    }
+    if (result.host && result.host !== '127.0.0.1' && result.host !== 'localhost') {
+      result.connections.incoming.net.push(net2) 
+      result.connections.incoming.ws.push(ws2) 
     }
   }
   return result

--- a/test.js
+++ b/test.js
@@ -1,3 +1,3 @@
 
 
-console.log(require('./inject')('testnet', {port: 9999, friends: {dunbar: 1500}}))
+console.log(JSON.stringify(require('./inject')('testnet', {port: 9999, friends: {dunbar: 1500}}),null, 2))


### PR DESCRIPTION
In the old days, multiserver servers bound to all interfaces. Now they only
bind to hosts that are explicitly configured in either `config.host` or
`config.connections.incoming.**.host`, or the host indirectly selected via a scope.

The old behaviour of binding to all interfaces was convenient, because
sbot would gossip on the LAN/Internet and would also allow the local cli client to
connect without any configuration.

This restores this convenient behaviour by creating additional local incomings
for net and ws as needed.

If you have a public IP, without any configuration, you end up with these incomings

- net/shs on public ip
- net/shs on localhost
- ws/shs on public ip
- ws/shs on localhost

and if you don't have a public IP:

- net/shs on private (lan) ip
- net/shs on localhost
- ws/shs on private (lan) ip
- ws/shs on localhost
