### PR TITLE
only generate/load keys if not specified in overrides

### DIFF
--- a/defaults.js
+++ b/defaults.js
@@ -74,7 +74,9 @@ module.exports = function setDefaults (name, config) {
   }
   config = fixConnections(config)
 
-  config.keys = ssbKeys.loadOrCreateSync(path.join(config.path, 'secret'))
+  if (!config.keys) {
+    config.keys = ssbKeys.loadOrCreateSync(path.join(config.path, 'secret'))
+  }
 
   return config
 }


### PR DESCRIPTION
Currently ssb-config will always load or generate the keys and ignore anything passed in as an "override". However this leaves no way to manually specify the keys and disable generation.

**This PR changes this behavior so that the key is only automatically loaded/generated if one was not specified in the override** (e.g. `ssbConfig('some-app', {keys: rootConfig.keys})`)