### PR TITLE
Fix keys setting

### DIFF
--- a/defaults.js
+++ b/defaults.js
@@ -74,7 +74,9 @@ module.exports = function setDefaults (name, config) {
   }
   config = fixConnections(config)
 
-  config.keys = ssbKeys.loadOrCreateSync(path.join(config.path, 'secret'))
+  if (config.keys == null) {
+    config.keys = ssbKeys.loadOrCreateSync(path.join(config.path, 'secret'))
+  }
 
   return config
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "ssb-keys": "^7.1.4"
   },
   "devDependencies": {
+    "ssb-client": "^4.7.1",
     "ssb-server": "latest",
     "tape": "^4.9.2"
   },

--- a/tests/inject.test.js
+++ b/tests/inject.test.js
@@ -1,0 +1,12 @@
+const test = require('tape')
+const ssbKeys = require('ssb-keys')
+
+var Config = require('../inject')
+
+test('setting custom host:port', t => {
+  const keys = ssbKeys.generate()
+  var config = Config('testnet', { keys })
+
+  t.equal(keys.public, config.keys.public,  'keys are correctly set')
+  t.end()
+})

--- a/tests/inject.test.js
+++ b/tests/inject.test.js
@@ -1,12 +1,19 @@
 const test = require('tape')
 const ssbKeys = require('ssb-keys')
 
-var Config = require('../inject')
+const Config = require('../inject')
 
-test('setting custom host:port', t => {
+test('default: no keys set', t => {
+  const config = Config('testnet')
+
+  t.ok(config.keys.public, 'keys exist')
+  t.end()
+})
+
+test('custom: keys injected', t => {
   const keys = ssbKeys.generate()
-  var config = Config('testnet', { keys })
+  const config = Config('testnet', { keys })
 
-  t.equal(keys.public, config.keys.public,  'keys are correctly set')
+  t.equal(keys.public, config.keys.public,  'keys exist')
   t.end()
 })


### PR DESCRIPTION
A previous commit accidentally did an override on the `keys` property so
that custom keys weren't accepted. This changes the behavior so that it
only does an override if `config.keys` is unset.

Resolves #44 