### PR TITLE
Switch back to IPv4 to conform to existing docs and unbreak tests

### DIFF
--- a/defaults.js
+++ b/defaults.js
@@ -59,13 +59,13 @@ module.exports = function setDefaults (name, config) {
   if (!config.connections.incoming) {
     config.connections.incoming = {
       net: [{
-        host: config.host || nonPrivate.v4 || '::',
+        host: config.host || nonPrivate.v4 || '0.0.0.0',
         port: config.port || defaultPorts.net,
         scope: ['device', 'local', 'public'],
         transform: 'shs'
       }],
       ws: [{
-        host: config.host || nonPrivate.v4 || '::',
+        host: config.host || nonPrivate.v4 || '0.0.0.0',
         port: get(config, 'ws.port', defaultPorts.ws),
         scope: ['device', 'local', 'public'],
         transform: 'shs'


### PR DESCRIPTION
It seems like The Right Way to go about this is to omit the host entirely so that Node.js can decide on a host automagically: 

> If host is omitted, the server will accept connections on the unspecified IPv6 address (::) when IPv6 is available, or the unspecified IPv4 address (0.0.0.0) otherwise.
>
> -- https://nodejs.org/api/net.html

...but we shouldn't do that until ssb-client knows that an omitted host means "try both `::` and `0.0.0.0`". In the meantime, this brings us back to an IPv4-only default config which unbreaks Travis and conforms to the code comments that say:

```js
    // just use an ipv4 address by default.
    // there have been some reports of seemingly non-private
    // ipv6 addresses being returned and not working.
    // https://github.com/ssbc/scuttlebot/pull/102
```