### PR TITLE
Remove non private ip

### DIFF
--- a/defaults.js
+++ b/defaults.js
@@ -1,5 +1,5 @@
 var path = require('path')
-var home = require('os-homedir')
+const { homedir } = require('os')
 var merge = require('deep-extend')
 var ssbKeys = require('ssb-keys')
 var get = require('lodash.get')
@@ -12,7 +12,7 @@ var MIN = 60 * SEC
 
 module.exports = function setDefaults (name, config) {
   var baseDefaults = {
-    path: path.join(home() || 'browser', '.' + name),
+    path: path.join(homedir() || 'browser', '.' + name),
     party: true,
     timeout: 0,
     pub: true,

--- a/defaults.js
+++ b/defaults.js
@@ -1,7 +1,6 @@
 var path = require('path')
 var home = require('os-homedir')
 var merge = require('deep-extend')
-var nonPrivate = require('non-private-ip')
 var ssbKeys = require('ssb-keys')
 var get = require('lodash.get')
 
@@ -13,10 +12,6 @@ var MIN = 60 * SEC
 
 module.exports = function setDefaults (name, config) {
   var baseDefaults = {
-    // just use an ipv4 address by default.
-    // there have been some reports of seemingly non-private
-    // ipv6 addresses being returned and not working.
-    // https://github.com/ssbc/scuttlebot/pull/102
     path: path.join(home() || 'browser', '.' + name),
     party: true,
     timeout: 0,
@@ -59,13 +54,13 @@ module.exports = function setDefaults (name, config) {
   if (!config.connections.incoming) {
     config.connections.incoming = {
       net: [{
-        host: config.host || nonPrivate.v4 || '::',
+        host: config.host || '::',
         port: config.port || defaultPorts.net,
         scope: ['device', 'local', 'public'],
         transform: 'shs'
       }],
       ws: [{
-        host: config.host || nonPrivate.v4 || '::',
+        host: config.host || '::',
         port: get(config, 'ws.port', defaultPorts.ws),
         scope: ['device', 'local', 'public'],
         transform: 'shs'

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "dependencies": {
     "deep-extend": "^0.6.0",
     "lodash.get": "^4.4.2",
-    "non-private-ip": "^1.2.1",
     "os-homedir": "^1.0.1",
     "rc": "^1.1.6",
     "ssb-keys": "^7.1.4"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "dependencies": {
     "deep-extend": "^0.6.0",
     "lodash.get": "^4.4.2",
-    "os-homedir": "^1.0.1",
     "rc": "^1.1.6",
     "ssb-keys": "^7.1.4"
   },

--- a/tests/server-startup.test.js
+++ b/tests/server-startup.test.js
@@ -1,12 +1,13 @@
 var test = require('tape')
 var Path = require('path')
 var Client = require('ssb-client')
-var home = require('os-homedir')()
-
+const { homedir } = require('os')
 var { fork } = require('child_process');
 
 var configDefault = require('./server/default.config.js')
 var configCustom = require('./server/custom.config.js')
+
+const home = homedir()
 
 if (process.env.SKIP_SERVER) {
   console.log('\n!! skipping server startup tests\n')


### PR DESCRIPTION
We want to bind on all possible interfaces unless explicitly configured
otherwise. This may resolve an issue where ssb-ws wasn't correctly
binding to the `localhost` IP.

See: ssbc/patchwork#1024

Also replaces os-homedir (deprecated) with `os.homedir()`. 