### PR TITLE
Automatically configure `config.connections.incoming` 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,2 @@
 language: node_js
-node_js:
-  - 6
-  - 8
-  - 10
+node_js: lts/*

--- a/defaults.js
+++ b/defaults.js
@@ -1,9 +1,9 @@
 var path = require('path')
 var home = require('os-homedir')
 var merge = require('deep-extend')
-var nonPrivate = require('non-private-ip')
 var ssbKeys = require('ssb-keys')
 var get = require('lodash.get')
+const os = require('os')
 
 var fixConnections = require('./util/fix-connections')
 var defaultPorts = require('./default-ports')
@@ -13,10 +13,6 @@ var MIN = 60 * SEC
 
 module.exports = function setDefaults (name, config) {
   var baseDefaults = {
-    // just use an ipv4 address by default.
-    // there have been some reports of seemingly non-private
-    // ipv6 addresses being returned and not working.
-    // https://github.com/ssbc/scuttlebot/pull/102
     path: path.join(home() || 'browser', '.' + name),
     party: true,
     timeout: 0,
@@ -56,22 +52,100 @@ module.exports = function setDefaults (name, config) {
   }
   config = merge(baseDefaults, config || {})
 
+  // We have to deal with some legacy behavior where:
+  //
+  // - net port is defined by `config.port`
+  // - ws port is defined by `config.ws.port`
+  // - other services have no canonical port config location (TODO?)
+  const getPort = (service) => {
+    const defaultPort = defaultPorts[service]
+
+    if (service === 'net' ) {
+      return get(config, 'port', defaultPort)
+    }
+    if (service === 'ws' ) {
+      return get(config, 'ws.port', defaultPort)
+    }
+
+    return defaultPort
+  }
+
   if (!config.connections.incoming) {
-    config.connections.incoming = {
-      net: [{
-        host: config.host || nonPrivate.v4 || '::',
-        port: config.port || defaultPorts.net,
-        scope: ['device', 'local', 'public'],
-        transform: 'shs'
-      }],
-      ws: [{
-        host: config.host || nonPrivate.v4 || '::',
-        port: get(config, 'ws.port', defaultPorts.ws),
-        scope: ['device', 'local', 'public'],
-        transform: 'shs'
-      }]
+    // We only use two scopes by default:
+    //
+    // - internal: inaccessible over the network
+    // - external: accessible over the network
+    //
+    const scope = {
+      internal: ['device'],
+      external: ['device', 'local', 'public']
+    }
+
+    // If `config.host` is defined then we don't need to enumerate interfaces.
+    if (config.host) {
+      config.connections.incoming = {
+        net: [{
+          host: config.host,
+          port: getPort('net'),
+          scope: scope.external,
+          transform: 'shs'
+        }],
+        ws: [{
+          host: config.host,
+          port: getPort('ws'),
+          scope: scope.external,
+          transform: 'shs'
+        }]
+      }
+    } else {
+      // Trying to hardcode reasonable defaults here doesn't seem possible.
+      //
+      // Instead, the below code enumerates all network interfaces and adds them
+      // to `config.connections.incoming` for each service in `defaultPorts`.
+
+      // If you aren't familiar, you should at least skim these docs:
+      // https://nodejs.org/api/os.html#os_os_networkinterfaces
+      const interfaces = os.networkInterfaces()
+
+      // Game plan: we're going to enumerate the services (e.g. net and ws) and
+      // return an object that looks like this:
+      //
+      // {
+      //   net: [ interface, interface, ... ]
+      //   ws: [ interface, interface, ... ]
+      // }
+      config.connections.incoming = Object.keys(defaultPorts).map((service) => {
+        return {
+          service,
+          interfaces: Object.values(interfaces).reduce((acc, val) => {
+            // Future TODO: replace with shiny new `Array.prototype.flat()`.
+            return acc.concat(val)
+          }).filter(item => {
+            // We want to avoid scoped IPv6 addresses since they don't seem to
+            // play nicely with the Node.js networking stack. These addresses
+            // often start with `fe80` and throw EINVAL when we try to bind to
+            // them. 
+            return item.scopeid == null || item.scopeid === 0
+          }).map(item => {
+            // This bit is simple because the ssb-config options for `incoming`
+            // can either be hardcoded or directly inferred from `interfaces`.
+            return {
+              host: item.address,
+              port: getPort(service),
+              scope: item.internal ? scope.internal : scope.external,
+              transform: 'shs'
+            }
+          })
+        }
+      }).reduce((result, obj) => {
+        // This `reduce()` step is necessary because we need to return an object
+        // rather than an array. There may be a simpler way to do this.
+        result[obj.service] = obj.interfaces;
+        return result
+      }, {})
     }
   }
+
   config = fixConnections(config)
 
   if (config.keys == null) {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "dependencies": {
     "deep-extend": "^0.6.0",
     "lodash.get": "^4.4.2",
-    "non-private-ip": "^1.2.1",
     "os-homedir": "^1.0.1",
     "rc": "^1.1.6",
     "ssb-keys": "^7.1.4"


### PR DESCRIPTION
This replaces the old hardcode method with a new automatic configuration
that iterates through `os.networkInterfaces()` and returns a valid
configuration that takes advantage of all possible interfaces.

This *should* give multiserver more addresses to broadcast.

## Before

```js
{ net:
   [ { host: '::',
       port: 8008,
       scope: [ 'device', 'local', 'public' ],
       transform: 'shs' } ],
  ws:
   [ { host: '::',
       port: 8989,
       scope: [ 'device', 'local', 'public' ],
       transform: 'shs' } ] }
```

## After

```js
{ net:
   [ { host: '127.0.0.1',
       port: 8008,
       scope: [ 'device' ],
       transform: 'shs' },
     { host: '::1', port: 8008, scope: [ 'device' ], transform: 'shs' },
     { host: '192.168.0.109',
       port: 8008,
       scope: [ 'device', 'local', 'public' ],
       transform: 'shs' },
     { host: '172.18.0.1',
       port: 8008,
       scope: [ 'device', 'local', 'public' ],
       transform: 'shs' },
     { host: 'fce2:9811:4862:81a7:bb08:91d6:2e41:d220',
       port: 8008,
       scope: [ 'device', 'local', 'public' ],
       transform: 'shs' } ],
  ws:
   [ { host: '127.0.0.1',
       port: 8989,
       scope: [ 'device' ],
       transform: 'shs' },
     { host: '::1', port: 8989, scope: [ 'device' ], transform: 'shs' },
     { host: '192.168.0.109',
       port: 8989,
       scope: [ 'device', 'local', 'public' ],
       transform: 'shs' },
     { host: '172.18.0.1',
       port: 8989,
       scope: [ 'device', 'local', 'public' ],
       transform: 'shs' },
     { host: 'fce2:9811:4862:81a7:bb08:91d6:2e41:d220',
       port: 8989,
       scope: [ 'device', 'local', 'public' ],
       transform: 'shs' } ] }
```

One interesting side-effect here is that if you run a node in a mesh network (e.g. cjdns) then that address is now being broadcast over LAN. If two people use both Scuttlebutt and cjdns on the same LAN then when they're far away I *think* they'll continue to peer over cjdns because the address is saved to `gossip.json`. Someone please correct me if I'm wrong here! 

---

Also Travis CI tests by filtering IPv6 addresses on Travis. :tada: 

---

Resolves #47 
Resolves #49 
Resolves #52 
Hopefully takes care of https://github.com/ssbc/patchwork/issues/958 and https://github.com/ssbc/patchwork/issues/1024
Paves the way to merging https://github.com/ssbc/multiserver/pull/42