### PR TITLE
Add onion to default outgoing connections and fix ssb-server dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ Defaults to the following:
     "net": [{ "port": 8008, "scope": "public", "transform": "shs" }]
   },
   "outgoing": {
-    "net": [{ "transform": "shs" }]
+    "net": [{ "transform": "shs" }],
+    "onion": [{ "transform": "shs" }]
   }
 }
 ```

--- a/defaults.js
+++ b/defaults.js
@@ -31,7 +31,8 @@ module.exports = function setDefaults (name, config) {
     },
     connections: {
       outgoing: {
-        net: [{ transform: 'shs' }]
+        net: [{ transform: 'shs' }],
+        onion: [{ transform: 'shs' }]
       }
     },
     timers: {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "ssb-client": "^4.7.1",
-    "ssb-server": "latest",
+    "ssb-server": "^14.1.12",
     "tape": "^4.9.2"
   },
   "author": "Dominic Tarr <dominic.tarr@gmail.com> (http://dominictarr.com)",


### PR DESCRIPTION
I was testing @mixmix's ssb-ahoy and noticed that when enabling and disabling tor-only I would end up with tor connections not working, this is because by default only net outgoing connections are enabled. Instead of added onion to the default in patchbay I think its better to add it here.

CC: @christianbundy as this might also have implications for patchwork.

Also this unbreaks current master as we have a dev-dep on latest?! scuttlebutt and 15 has a breaking change.