### PR TITLE
Fix non-strict syntax by removing global return

### DIFF
--- a/tests/server-startup.test.js
+++ b/tests/server-startup.test.js
@@ -10,7 +10,8 @@ var configCustom = require('./server/custom.config.js')
 
 if (process.env.SKIP_SERVER) {
   console.log('\n!! skipping server startup tests\n')
-  return 
+  // HACK: this skips the tests as an alternative to a global `return`
+  test = function () {}
 }
 
 test('Server startup - default config', t => {


### PR DESCRIPTION
This resolves an issue where the module wasn't able to be parsed in strict mode.

See: ssbc/ssb-server#683