### PR TITLE
Fix empty array error caused by reduce()

### DIFF
--- a/util/incoming-connections.js
+++ b/util/incoming-connections.js
@@ -73,7 +73,7 @@ module.exports = function (config) {
         interfaces: Object.values(interfaces).reduce((acc, val) => {
           // Future TODO: replace with shiny new `Array.prototype.flat()`.
           return acc.concat(val)
-        }).filter(item => {
+        }, []).filter(item => {
           // We want to avoid scoped IPv6 addresses since they don't seem to
           // play nicely with the Node.js networking stack. These addresses
           // often start with `fe80` and throw EINVAL when we try to bind to


### PR DESCRIPTION
When there are no interfaces the `interfaces` variable is set to an
empty array, which doesn't play nicely with reduce(). This commit sets
the initial value of reduce to `[]`, which lets us concatenate the
arrays without throwing a TypeError. The error being solved, which was
reported by @powersource:

```
Uncaught TypeError: Reduce of empty array with no initial value
    at Array.reduce (<anonymous>)
    at eval (incoming-connections.js?7e6a:73)
    at Array.map (<anonymous>)
    at module.exports (incoming-connections.js?7e6a:70)
    at setDefaults (defaults.js?34c4:49)
    at module.exports (inject.js?73a7:7)
    at module.exports (index.js?9885:23)
    at eval (main.js?56d7:9)
    at Module../src/main.js (app.js:992)
    at __webpack_require__ (app.js:786)
```