### PR TITLE
detect which scopes a interface can be used for

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,20 @@ likewise, `onion` should be in the public scope, because you can connect to it o
 
 ---
 
+#### scopes
+
+An address scope is the area from which it's possible to connect to an address.
+* `device` means connections can only come from the same device. (talking to your self)
+* `local` means connections can only come from the same network, i.e. same wifi.
+* `public` means connections can come from anywhere on the internet.
+
+Some protocols only work in particular scopes. `unix` socket requires fs access,
+so it only works for the device scope. `onion` (tor) routes connections through a distributed network,
+so it only works if you are fully connected to the `public` internet. Some mesh networks
+are really large, so they might seem public. Some overlay networks, such as cjdns and
+ZeroTeirOne create a fake local network that is publically accessable (these should
+be manually configured as public addresses!)
+
 ### Example `connnections` configurations
 
 If you only want to use [Tor](https://torproject.org) to create outgoing connections you can specify your `outgoing` like this. It will use `localhost:9050` as the socks server for creating this.

--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ are really large, so they might seem public. Some overlay networks, such as cjdn
 ZeroTeirOne create a fake local network that is publically accessable (these should
 be manually configured as public addresses!)
 
+most ssb peers just have a local and device scopes. pubs require a public scope.
+`ssb-tunnel` allows any peer to have a public address, by routing connections through a friendly pub.
+
 ### Example `connnections` configurations
 
 If you only want to use [Tor](https://torproject.org) to create outgoing connections you can specify your `outgoing` like this. It will use `localhost:9050` as the socks server for creating this.


### PR DESCRIPTION
fixes https://github.com/ssbc/ssb-config/issues/63

binds each interface to just one scope. that means `sbot.getAddress('local')` will return a 192... (or whatever, possibly including ipv6, etc. and `sbot.getAddress('device')` will return 'localhost'.

basically this was the code inside of non-private-ip, which was just a wrapper for the `ip` module but assumed you wanted a single host which made sense before we had multiserver and scopes etc