### PR TITLE
Change default friends.hops to 2

### DIFF
--- a/defaults.js
+++ b/defaults.js
@@ -19,7 +19,7 @@ module.exports = function setDefaults (name, config) {
     local: true,
     friends: {
       dunbar: 150,
-      hops: 3
+      hops: 2
     },
     gossip: {
       connections: 3


### PR DESCRIPTION
This is the default in Patchwork, Patchbay, and Manyverse, and I think it's a reasonable default for ssb-config.