### PR TITLE
Add incoming connection for Unix socket

### DIFF
--- a/util/incoming-connections.js
+++ b/util/incoming-connections.js
@@ -106,5 +106,7 @@ module.exports = function (config) {
     }, {})
   }
 
+  incoming.unix = [{ "scope":"device", "transform":"noauth" }]
+
   return incoming
 }


### PR DESCRIPTION
Problem: The Multiserver plugin exposes a Unix socket by default, and
it's way faster on low-end devices and devices that are forced to use
JavaScript cryptography, but it isn't enabled in SSB-Config.

Solution: Add a line to set it as an incoming connection, so that it's
available by default.