### PR TITLE
update README: net external should be a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Each transport can have an array of different configurations passed to it, these
 - `host` _(string)_ IP or hostname that the listener is binding on.
 - `scope` _(string | array of string)_ scope Determines the set of network interfaces to bind the server to. 
 If scope is an array, then the server will bind to all the selected ports. [See more about scopes below](#scopes).
-- `external` _(array of strings)_ For use in combination with public scope. this is the external domain given 
+- `external` _(string)_ For use in combination with public scope. this is the external domain given 
 out as the address to peers.
 - `key` _(string)_ Used together with `cert` for ws plugin to run over TLS (wss). Needs to be a path to where 
 the key is stored.
@@ -191,7 +191,7 @@ can specify a `public` scope as your `incoming.net` by defining the `external` p
 { 
   "incoming": {
     "net": [
-      { "scope": "public",  "external": ["cryptop.home"], "transform": "shs", "port": 8008 },
+      { "scope": "public",  "external": "cryptop.home", "transform": "shs", "port": 8008 },
       { "scope": "private", "transform": "shs", "port": 8008, "host": "internal1.con.taine.rs" },
     ]
   },


### PR DESCRIPTION
See this issue for context: https://github.com/ssb-js/secret-stack/issues/62

As far as I can see, ssb-config doesn't handle `external` at all, `multiserver`'s `net` plugin handles it, and it seems like it has not supported array of strings, not in the recent past (up to 2 years ago), see: https://github.com/ssb-js/multiserver/blob/7d47892757c14732b47662d81e36dd21f3c16b6b/plugins/net.js#L108

There used to be a time that passing `external` as an array wouldn't *crash*, because `stringify()` returned `['net', host, port].join(':')`, and if `host` was the array `['google.com', 'facebook.com']`, then `stringify()` would return `'net:google.com,facebook.com:2850'` which **is not a valid multiserver address**. Long story short: I don't think multiserver net ever supported arrays for this.