### PR TITLE
Update ssb-keys to 8.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "os-homedir": "^1.0.1",
     "rc": "^1.1.6",
     "ssb-caps": "^1.0.1",
-    "ssb-keys": "^7.1.4"
+    "ssb-keys": "^8.2.0"
   },
   "devDependencies": {
     "scuttle-testbot": "^1.2.3",


### PR DESCRIPTION
Context: If I have both ssb-config and ssb-keys installed in my project as `ssb-keys@8.2.0` then `ssb-config` will bring its own duplicate of ssb-keys as `ssb-keys@7.1.4`. 

I would like to remove some of this duplicate code shipped to end-users, and the only function that ssb-config is using is `loadOrCreateSync`, [which has not changed between those versions except for semicolons](https://github.com/ssb-js/ssb-keys/compare/ssb-js:3df613c...ssb-js:6806a86#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346R72-R78).